### PR TITLE
Add ABI support for arm64-v8a

### DIFF
--- a/src/main/jni/Application.mk
+++ b/src/main/jni/Application.mk
@@ -1,4 +1,4 @@
-APP_ABI      			:= armeabi-v7a x86
+APP_ABI      			:= armeabi-v7a arm64-v8a x86
 APP_PLATFORM 			:= android-19
-APP_STL      			:= stlport_static
+APP_STL      			:= c++_static
 NDK_TOOLCHAIN_VERSION 	:= clang


### PR DESCRIPTION
Although simple-obfs is deprecated, but it's still available. Start from Pixel 7, Google wouldn't support 32bits app. By make this change can allow install the Android client on those devices.