### PR TITLE
Fix SIGILL crash on Android 16 (HyperOS 3.0)

### DIFF
--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -98,7 +98,7 @@ set(OBFS_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/../jni/simple-obfs/src/android.c
 )
 
-add_library(obfs-local SHARED ${OBFS_SOURCES})
+add_executable(obfs-local ${OBFS_SOURCES})
 
 target_compile_definitions(obfs-local PRIVATE
     MODULE_LOCAL
@@ -116,5 +116,7 @@ target_link_libraries(obfs-local
 
 # Set the linker flags to make it executable
 set_target_properties(obfs-local PROPERTIES
-    LINK_FLAGS "-pie -fPIE"
+    OUTPUT_NAME obfs-local
+    PREFIX "lib"
+    SUFFIX ".so"
 )


### PR DESCRIPTION
# Fix SIGILL crash on Android 16 (HyperOS 3.0)

### Summary / 概述
**English:** This PR fixes a critical crash (`SIGILL`) of the `simple-obfs` plugin on newer Android versions (specifically tested on **Android 16**, **HyperOS 3.0**). The issue was caused by an incorrect build configuration where the executable was being built as a shared library, leading to illegal instruction errors when the system attempted to execute it.

**中文：** 本 PR 修复了 `simple-obfs` 插件在较新 Android 版本（在 **Android 16**, **澎湃OS 3.0** 上实测）下出现的严重崩溃（`SIGILL`）问题。问题根源在于原有的编译配置将可执行文件作为共享库（Shared Library）构建，导致系统尝试执行时触发“非法指令”错误。

---

### Environment / 环境信息
* **Device:** Redmi K80 Ultra
* **OS:** HyperOS 3.0.7.0.VONCNXM (Android 16)
* **App:** Shadowsocks-android with simple-obfs-android plugin

---

### Problem & Analysis / 问题与分析
**English:** When enabling the simple-obfs plugin, Shadowsocks failed to connect. Logcat revealed the following error:
`ERROR plugin exited with status: signal: 4 (SIGILL)`

The analysis suggests that on modern Android/Kernel environments, forcing a `SHARED` library to act as an executable via `-pie` flags can lead to memory execution violations or entry point mismatches, resulting in the `SIGILL` signal.

**中文：** 开启插件后，Shadowsocks 无法联网。Logcat 日志显示：
`ERROR plugin exited with status: signal: 4 (SIGILL)`

经过分析发现，在现代 Android/内核环境下，通过 `-pie` 标志强制让 `SHARED` 库作为可执行文件运行，会导致内存执行权限校验失败或入口点匹配错误，从而触发 `SIGILL`（非法指令）信号。

---

### Changes / 改动内容
**English:** 1. Changed `add_library(obfs-local SHARED ...)` to `add_executable(obfs-local ...)`.
2. Explicitly set target properties to maintain the `libobfs-local.so` naming convention to ensure the APK packaging and Shadowsocks' plugin loading logic remain compatible.
3. This ensures the binary has a proper ELF execution header while still being recognized as a native library by the Android package manager for proper extraction.

**中文：** 1. 将 `add_library(obfs-local SHARED ...)` 修改为 `add_executable(obfs-local ...)`。
2. 显式设置目标属性，保持 `libobfs-local.so` 的命名约定，以确保 APK 打包逻辑和 Shadowsocks 的插件加载逻辑保持兼容。
3. 这样做确保了二进制文件拥有正确的 ELF 执行头，同时仍能被 Android 包管理器识别为原生库并正确解压。

---

### Note to Reviewers / 给维护者的说明
**English:** I am not a developer with an Android-native background. Although this change has been verified to work perfectly on my Redmi K80 Ultra (Android 16), please review the implications for older Android versions carefully. If this aligns with the project's compatibility goals, please consider merging.

**中文：** 我并非专业的安卓背景开发者。虽然该改动已在我的 Redmi K80 Ultra (Android 16) 上通过测试并能正常上网，但还请各位维护者仔细评估此改动对旧版本 Android 的影响。如果符合项目的兼容性目标，请考虑合并。